### PR TITLE
feat: Add placeholder modals for navigation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -2128,6 +2128,98 @@ body::before {
     </div>
   </div>
 
+<!-- ================================================================================= -->
+<!-- GENERATED PLACEHOLDER MODALS -->
+<!-- ================================================================================= -->
+
+<!-- Blog Modal -->
+<div class="modal" id="blogModal">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h2 class="modal-title">Blog</h2>
+      <button class="modal-close" data-modal-close="blogModal" aria-label="Close modal"><i class="fas fa-times"></i></button>
+    </div>
+    <div class="modal-body"><p>Blog content coming soon. Stay tuned!</p></div>
+  </div>
+</div>
+
+<!-- Code Playground Modal -->
+<div class="modal" id="codePlaygroundModal">
+  <div class="modal-content modal-content--large">
+    <div class="modal-header">
+      <h2 class="modal-title">Code Playground</h2>
+      <button class="modal-close" data-modal-close="codePlaygroundModal" aria-label="Close modal"><i class="fas fa-times"></i></button>
+    </div>
+    <div class="modal-body"><p>Interactive code playground coming soon. Stay tuned!</p></div>
+  </div>
+</div>
+
+<!-- Tools Modal -->
+<div class="modal" id="toolsModal">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h2 class="modal-title">Tools</h2>
+      <button class="modal-close" data-modal-close="toolsModal" aria-label="Close modal"><i class="fas fa-times"></i></button>
+    </div>
+    <div class="modal-body"><p>A collection of useful development tools is coming soon. Stay tuned!</p></div>
+  </div>
+</div>
+
+<!-- Changelog Modal -->
+<div class="modal" id="changelogModal">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h2 class="modal-title">Changelog</h2>
+      <button class="modal-close" data-modal-close="changelogModal" aria-label="Close modal"><i class="fas fa-times"></i></button>
+    </div>
+    <div class="modal-body"><p>Project changelog and updates coming soon. Stay tuned!</p></div>
+  </div>
+</div>
+
+<!-- Tech Specs Modal -->
+<div class="modal" id="techSpecsModal">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h2 class="modal-title">Technical Specifications</h2>
+      <button class="modal-close" data-modal-close="techSpecsModal" aria-label="Close modal"><i class="fas fa-times"></i></button>
+    </div>
+    <div class="modal-body"><p>Detailed technical specifications for this portfolio are coming soon. Stay tuned!</p></div>
+  </div>
+</div>
+
+<!-- Currently Learning Modal -->
+<div class="modal" id="currentlyLearningModal">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h2 class="modal-title">Currently Learning</h2>
+      <button class="modal-close" data-modal-close="currentlyLearningModal" aria-label="Close modal"><i class="fas fa-times"></i></button>
+    </div>
+    <div class="modal-body"><p>A list of technologies and concepts I'm currently exploring is coming soon. Stay tuned!</p></div>
+  </div>
+</div>
+
+<!-- GitHub Modal -->
+<div class="modal" id="githubModal">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h2 class="modal-title">GitHub Activity</h2>
+      <button class="modal-close" data-modal-close="githubModal" aria-label="Close modal"><i class="fas fa-times"></i></button>
+    </div>
+    <div class="modal-body"><p>Live GitHub activity feed coming soon. Stay tuned!</p></div>
+  </div>
+</div>
+
+<!-- Comments Modal -->
+<div class="modal" id="commentsModal">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h2 class="modal-title">Discussion</h2>
+      <button class="modal-close" data-modal-close="commentsModal" aria-label="Close modal"><i class="fas fa-times"></i></button>
+    </div>
+    <div class="modal-body"><p>A space for discussion and comments is coming soon. Stay tuned!</p></div>
+  </div>
+</div>
+
 <script>
 // =================================================================================
 // MAIN APP LOGIC


### PR DESCRIPTION
This commit adds 8 new placeholder modals to the `index.html` file in response to your request. The navigation buttons for "Blog", "Playground", "Tools", etc., now open a corresponding modal with a "Coming soon" message.

This provides feedback to you that the links are active, even if the full feature is not yet implemented.

The following modals were added:
- blogModal
- codePlaygroundModal
- toolsModal
- changelogModal
- techSpecsModal
- currentlyLearningModal
- githubModal
- commentsModal