### PR TITLE
fix: Make blog generator modal responsive on smaller screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -2209,6 +2209,16 @@ body::before {
              .generator-form .form-group {
                 margin-bottom: 1rem;
             }
+            @media (max-width: 992px) {
+                #blog-generator-body {
+                    grid-template-columns: 1fr;
+                    height: auto;
+                }
+                .generator-form, .generator-preview-area {
+                    overflow-y: visible;
+                    padding-right: 0;
+                }
+            }
         </style>
         <div class="generator-form">
             <h3><i class="fas fa-pencil-alt"></i> Content</h3>


### PR DESCRIPTION
The previous two-column layout for the blog generator was not usable on mobile devices.

This commit adds a CSS media query that triggers on screens narrower than 992px. Inside this query, the grid layout is changed to a single column, stacking the content form and the template preview area vertically. This makes the feature accessible and well-organized on all device sizes.