### PR TITLE
Fix: Correct layout of playground modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -1740,7 +1740,8 @@ body::before {
 #playground-body {
     display: flex;
     flex-direction: column;
-    height: 100%;
+    flex: 1;
+    min-height: 0;
     padding: 1rem;
     overflow: hidden;
 }
@@ -1790,7 +1791,6 @@ body::before {
     min-height: 0;
     display: grid;
     grid-template-columns: 1fr 1fr;
-    height: 100%;
     overflow: hidden;
     gap: 1rem;
     padding: 1rem;


### PR DESCRIPTION
The playground modal content was not visible due to incorrect height calculations in the flexbox layout.

- Modified the `#playground-body` CSS to use `flex: 1` and `min-height: 0` instead of `height: 100%`. This allows the modal body to correctly fill the available space within its flex container.
- Removed the redundant `height: 100%` from the `.playground-container` CSS rule, as `flex-grow: 1` is sufficient for it to scale properly.

These changes ensure the modal's content renders correctly and is visible to you.