### PR TITLE
feat: Implement GitHub repositories modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -1913,6 +1913,82 @@ body::before {
     white-space: nowrap;
 }
 
+/* GitHub Modal Styles */
+#github-modal-body {
+    background-color: var(--bg-primary);
+    padding: 1.5rem;
+    max-height: calc(90vh - 120px); /* Adjust based on header/footer height */
+    overflow-y: auto;
+}
+
+#github-repo-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.repo-card {
+    background: var(--gradient-glass);
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.repo-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.repo-title {
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.repo-date {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.repo-description {
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+.repo-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-color);
+}
+
+.repo-actions {
+    display: flex;
+    gap: 1rem;
+}
+
+.repo-actions .btn {
+    padding: 0.6rem 1.2rem;
+    font-size: 0.9rem;
+}
+
+.repo-changelog {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
 </style>
 </head>
 
@@ -1965,7 +2041,7 @@ body::before {
       <a href="javascript:void(0);" class="nav-item" data-modal-target="currentlyLearningModal">
         <i class="fas fa-book-open"></i> <span>Learning</span>
       </a>
-      <a href="javascript:void(0);" class="nav-item" data-modal-target="githubModal">
+      <a href="javascript:void(0);" id="github-nav-button" class="nav-item" data-modal-target="githubModal" style="pointer-events: none; opacity: 0.5;">
         <i class="fab fa-github"></i> <span>GitHub</span>
       </a>
       <a href="javascript:void(0);" class="nav-item" data-modal-target="commentsModal">
@@ -2706,12 +2782,16 @@ body::before {
 
 <!-- GitHub Modal -->
 <div class="modal" id="githubModal">
-  <div class="modal-content">
+  <div class="modal-content modal-content--large">
     <div class="modal-header">
-      <h2 class="modal-title">GitHub Activity</h2>
+      <h2 class="modal-title">GitHub Repositories</h2>
       <button class="modal-close" data-modal-close="githubModal" aria-label="Close modal"><i class="fas fa-times"></i></button>
     </div>
-    <div class="modal-body"><p>Live GitHub activity feed coming soon. Stay tuned!</p></div>
+    <div class="modal-body modal-body--single-col" id="github-modal-body">
+      <div id="github-repo-list">
+        <!-- Repository list will be dynamically inserted here -->
+      </div>
+    </div>
   </div>
 </div>
 
@@ -2747,6 +2827,11 @@ document.addEventListener('DOMContentLoaded', function() {
     .then(data => {
       projects = data;
       renderProjects();
+      const githubButton = document.getElementById('github-nav-button');
+      if (githubButton) {
+          githubButton.style.pointerEvents = 'auto';
+          githubButton.style.opacity = '1';
+      }
     })
     .catch(error => console.error('Error fetching projects:', error));
 
@@ -3091,7 +3176,7 @@ function openModalById(modalId, event, downloadProjectId = null) {
     } else if (modalId === 'codePlaygroundModal') {
         runCode();
     } else if (modalId === 'githubModal') {
-        fetchGithubActivity();
+        renderGithubRepositories();
     }
 }
 
@@ -3319,10 +3404,6 @@ function runCode() {
     console.log("Code playground not implemented yet.");
 }
 
-function fetchGithubActivity() {
-    console.log("GitHub activity fetch not implemented yet.");
-}
-
 // Notification system
 function showNotification(message, type = 'info') {
   const notification = document.createElement('div');
@@ -3436,6 +3517,46 @@ function handleRequestSubmission(event) {
     showNotification('Thank you! Your request has been prepared for sending.', 'success');
     closeModalById('request-modal');
     form.reset();
+}
+
+function renderGithubRepositories() {
+    const repoListContainer = document.getElementById('github-repo-list');
+    if (!repoListContainer) return;
+
+    const githubProjects = projects.filter(p => p.github && p.github !== '#');
+
+    if (githubProjects.length === 0) {
+        repoListContainer.innerHTML = '<p style="text-align: center; color: var(--text-secondary); padding: 2rem;">No public repositories found.</p>';
+        return;
+    }
+
+    const repoListHTML = githubProjects.map(repo => `
+        <div class="repo-card">
+            <div class="repo-header">
+                <h3 class="repo-title">${repo.title}</h3>
+                <div class="repo-date">Created on: ${formatDate(repo.date)}</div>
+            </div>
+            <p class="repo-description">${repo.description}</p>
+            <div class="repo-tags">
+                ${repo.tags.map(tag => `<span class="tag">${tag}</span>`).join('')}
+            </div>
+            <div class="repo-footer">
+                <div class="repo-actions">
+                    <a href="${repo.github}" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
+                        <i class="fab fa-github"></i> View Code
+                    </a>
+                    <button class="btn btn-primary" onclick="openModalById('download-modal', event, ${repo.id})">
+                        <i class="fas fa-download"></i> Download
+                    </button>
+                </div>
+                <div class="repo-changelog">
+                    <i class="fas fa-history"></i> Changelog: Coming Soon
+                </div>
+            </div>
+        </div>
+    `).join('');
+
+    repoListContainer.innerHTML = repoListHTML;
 }
 
 async function generateBlogPreview() {


### PR DESCRIPTION
This commit implements a new feature: a GitHub repositories modal.

- Creates a new layout for the GitHub modal to display a list of repositories.
- Adds a JavaScript function to dynamically render repository information from the `projects.json` file, including title, description, creation date, and tags.
- Includes "View Code" and "Download" buttons for each repository.
- Fixes a race condition by disabling the GitHub navigation button until project data is loaded, ensuring data is available before rendering.
- Adds CSS to style the new modal content for a consistent look and feel.