### PR TITLE
The live demo link for the "MYK Portfolio Platform" project was missi…

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -15,7 +15,7 @@
     "price": 75000,
     "status": "live",
     "date": "2025-07-20",
-    "demo": "https://garymike07.github.io/myk",
+    "demo": "https://garymike07.github.io/myk/",
     "github": "https://github.com/garymike07/myk",
     "features": [
       "Real-time clock display",


### PR DESCRIPTION
…ng a trailing slash. This commit updates the URL in `projects.json` to `https://garymike07.github.io/myk/` as requested.