### PR TITLE
refactor(portfolio): Remove screenshots from project modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -1162,8 +1162,7 @@ body::before {
 
 .modal-body {
   display: grid;
-  grid-template-columns: 2fr 1fr; /* 2/3 for gallery, 1/3 for details */
-  gap: 2rem;
+  grid-template-columns: 1fr;
   padding: 2rem;
   height: 100%;
   overflow: hidden;
@@ -2390,12 +2389,6 @@ body::before {
         </button>
       </div>
       <div class="modal-body">
-        <div class="modal-gallery">
-          <img id="modal-main-image" src="" alt="Main project image" class="modal-main-image"/>
-          <div id="modal-thumbnails" class="modal-thumbnails">
-            <!-- Thumbnails will be dynamically inserted here -->
-          </div>
-        </div>
         <div id="modal-details" class="modal-details">
           <!-- Project details will be dynamically inserted here -->
         </div>
@@ -3535,25 +3528,6 @@ function openProjectModal(projectId) {
   
   document.getElementById('modal-title').textContent = project.title;
   
-  const mainImage = document.getElementById('modal-main-image');
-  mainImage.loading = 'lazy';
-  const thumbnailsContainer = document.getElementById('modal-thumbnails');
-  thumbnailsContainer.innerHTML = '';
-  
-  const thumbnails = project.thumbnails && project.thumbnails.length > 0 ? project.thumbnails : [project.image];
-  mainImage.src = thumbnails[0];
-  
-  thumbnails.forEach((thumbSrc, index) => {
-    const thumb = document.createElement('img');
-    thumb.src = thumbSrc;
-    thumb.alt = `${project.title} thumbnail ${index + 1}`;
-    thumb.className = 'modal-thumbnail';
-    thumb.loading = 'lazy';
-    if (index === 0) thumb.classList.add('active');
-    thumb.onclick = () => selectThumbnail(thumbSrc, index);
-    thumbnailsContainer.appendChild(thumb);
-  });
-
   const detailsContainer = document.getElementById('modal-details');
   let featuresHTML = project.features ? `
     <h4 class="modal-section-title">Key Features</h4>
@@ -3592,13 +3566,6 @@ function openProjectModal(projectId) {
   demoText.textContent = project.status === 'live' ? 'Live Demo' : (project.status === 'ongoing' ? 'Preview (Beta)' : 'Not Available');
 
   openModalById('project-modal');
-}
-
-function selectThumbnail(imageSrc, index) {
-  document.getElementById('modal-main-image').src = imageSrc;
-  document.querySelectorAll('.modal-thumbnail').forEach((thumb, i) => {
-    thumb.classList.toggle('active', i === index);
-  });
 }
 
 // =================================================================================

--- a/server.log
+++ b/server.log
@@ -1,0 +1,11 @@
+127.0.0.1 - - [08/Aug/2025 15:19:30] "GET /index.html HTTP/1.1" 200 -
+127.0.0.1 - - [08/Aug/2025 15:19:30] "GET /myk_thumb_2.png HTTP/1.1" 200 -
+127.0.0.1 - - [08/Aug/2025 15:19:30] "GET /myk_thumb_3.png HTTP/1.1" 200 -
+127.0.0.1 - - [08/Aug/2025 15:19:30] "GET /myk_logo.webp HTTP/1.1" 200 -
+127.0.0.1 - - [08/Aug/2025 15:19:30] "GET /myk_thumb_4.png HTTP/1.1" 200 -
+127.0.0.1 - - [08/Aug/2025 15:19:30] "GET /myk_thumb_1.png HTTP/1.1" 200 -
+127.0.0.1 - - [08/Aug/2025 15:19:31] "GET /projects.json HTTP/1.1" 200 -
+127.0.0.1 - - [08/Aug/2025 15:19:31] "GET /ecommerce_analytics_main.png HTTP/1.1" 200 -
+127.0.0.1 - - [08/Aug/2025 15:19:31] "GET /ai_cms_main.png HTTP/1.1" 200 -
+127.0.0.1 - - [08/Aug/2025 15:19:31] "GET /blockchain_voting_main.png HTTP/1.1" 200 -
+127.0.0.1 - - [08/Aug/2025 15:19:31] "GET /real_estate_main.png HTTP/1.1" 200 -


### PR DESCRIPTION
This commit refactors the project modals to remove the image gallery, which previously displayed screenshots of the projects.

The key changes are:
- The HTML for the `modal-gallery` has been removed from `index.html`.
- The CSS for the `modal-body` has been adjusted to allow the `modal-details` section to take up the full width of the modal.
- The JavaScript function `openProjectModal` has been updated to remove the logic for populating the image gallery.
- The `selectThumbnail` function, which was only used by the gallery, has been removed.

This change provides more space for detailed project information within the modals and simplifies the modal's structure.